### PR TITLE
docs: avaliar reativação do projeto legado e alinhar README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,26 @@
 
 > Aluno Matheus Ricelly
 
+## Estado do projeto
+
+Este projeto utiliza stack legada (Vue 2 + Quasar 0.14 + Webpack 3), mas ainda compila no ambiente atual.
+
+Para uma análise de reativação e plano de modernização, consulte:
+
+- [`docs/avaliacao-reativacao-2026.md`](docs/avaliacao-reativacao-2026.md)
+
 ## Build Setup
 
-``` bash
-# instalar o VueJs
-$ npm install -g vue-cli
+```bash
+# instalar dependências
+npm install
 
-# instalar o Quasar 
-# npm install -g quasar
+# ambiente de desenvolvimento
+npm run dev
 
-# instalar dependencia
-$ npm install
+# build de produção
+npm run build
 
-# carregar o app atraves de localhost:8080
-$ quasar dev
-
-# build for production with minification
-$ quasar build
-
-# lint code
-$ quasar lint
+# lint
+npm run lint
 ```

--- a/docs/avaliacao-reativacao-2026.md
+++ b/docs/avaliacao-reativacao-2026.md
@@ -1,0 +1,80 @@
+# Avaliação de Reativação do Projeto `calc-bin` (março/2026)
+
+## 1) Estado atual (diagnóstico rápido)
+
+- **Stack principal**: Vue 2.3 + Quasar Framework 0.14 + Webpack 3 + Babel 6.
+- **Build local**: `npm run lint` e `npm run build` executam com sucesso no ambiente atual.
+- **Sinais de obsolescência**:
+  - Dependências muito antigas e fora do ciclo de manutenção.
+  - Ferramentas de build legadas (`webpack 3`, `babel 6`, `eslint-loader`, `json-loader`).
+  - README ainda orientado ao fluxo antigo com `quasar dev/build/lint`, enquanto os scripts reais do projeto usam `node build/script.*.js`.
+
+## 2) Risco técnico para “reativar sem mexer”
+
+É **possível subir o projeto no curto prazo** sem alteração estrutural, mas com risco alto de:
+
+- Quebra em máquinas com versões recentes de Node/npm.
+- Maior exposição a CVEs de dependências transientes antigas.
+- Dificuldade de manutenção (onboarding e atualização de tooling).
+
+Em resumo: **reativar do jeito atual é viável só como contingência temporária**.
+
+## 3) Precisaremos de breaking change?
+
+### Resposta curta
+
+**Sim, muito provavelmente haverá breaking change** se a meta for reativação sustentável.
+
+### Por quê
+
+A atualização para ecossistema moderno (Vue 3 + Quasar atual + Vite) implica mudanças de:
+
+- API de componentes e lifecycle.
+- plugins e bootstrap.
+- cadeia de build e lint.
+
+Mesmo que a regra de negócio (conversão de bases) seja simples, a camada de framework/build terá mudanças incompatíveis.
+
+## 4) Estratégia recomendada
+
+### Opção A — “Sobrevida rápida” (sem breaking externo, curto prazo)
+
+Objetivo: recolocar em produção rapidamente com mínima alteração funcional.
+
+1. Congelar versão de Node via `.nvmrc` e documentar versão suportada.
+2. Ajustar README para comandos reais (`npm run dev/build/lint`).
+3. Executar auditoria de dependências e corrigir o que não quebrar API.
+4. Publicar como versão de manutenção.
+
+**Prós**: menor esforço imediato.  
+**Contras**: dívida técnica permanece alta.
+
+### Opção B — “Reativação correta” (com breaking controlado)
+
+Objetivo: tornar o projeto mantível pelos próximos anos.
+
+1. Criar branch/versão major (ex.: `v1 -> v2`).
+2. Migrar gradualmente para stack moderna (Vue/Quasar atuais, build moderno).
+3. Extrair e cobrir a lógica de conversão com testes unitários.
+4. Validar comportamento com testes de regressão (entrada/saída de conversão).
+5. Publicar guia de migração (breaking notes).
+
+**Prós**: manutenção e segurança muito melhores.  
+**Contras**: exige planejamento e janela de mudança.
+
+## 5) Recomendação final
+
+Se a intenção é **reativar para uso contínuo**, recomendo:
+
+- Fazer uma entrega curta de estabilização (Opção A) para voltar a operar.
+- Em paralelo, iniciar migração major (Opção B) já com cronograma.
+
+Isso reduz risco operacional hoje sem perpetuar o legado indefinidamente.
+
+## 6) Próximos passos práticos (1 a 2 semanas)
+
+1. Definir versão alvo de Node e publicar no repositório.
+2. Adicionar testes unitários para as conversões (bin/dec/hex/oct).
+3. Corrigir documentação de execução local.
+4. Levantar backlog de migração (framework, build, lint, CI).
+5. Decidir data de corte para release major com breaking change.


### PR DESCRIPTION
### Motivation
- O repositório usa uma stack legada (Vue 2 / Quasar 0.14 / Webpack 3 / Babel 6) e precisava de um diagnóstico e plano para reativação ordenada.
- É necessário distinguir uma intervenção de curto prazo (sobrevida) de uma migração sustentável que provavelmente implicará breaking changes.

### Description
- Adiciona `docs/avaliacao-reativacao-2026.md` com diagnóstico técnico, análise de riscos e uma estratégia em duas trilhas (Opção A: estabilização rápida; Opção B: migração major).
- Atualiza `README.md` para documentar os comandos reais de execução (`npm install`, `npm run dev`, `npm run build`, `npm run lint`) e referenciar o novo documento de avaliação.
- O material consolidado inclui recomendações práticas (congelar versão de Node, adicionar testes unitários para a lógica de conversão e planejar release major com notas de breaking). 

### Testing
- Executed `npm run lint`, which completed successfully without blocking errors. 
- Executed `npm run build`, which completed successfully and produced the `/dist` build although runtime warnings from legacy dependencies were emitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c26e9fa0bc8333825860a5b47f42dc)